### PR TITLE
Months granularity

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Inspired by TED talk: [Tim Urban: Inside the mind of master procrastinator](http
 Usage: ./lifecal.rb <birthdate> [options]
     -s, --stdout                     Print output to stdout [default]
     -f, --file FILE                  Render output as html file
+    -g--granularity [GRANULARITY]    Select time granularity (weeks, months), default: weeks
     -h, --help                       Show this message
 
 ```

--- a/lifecal.html.erb
+++ b/lifecal.html.erb
@@ -32,10 +32,10 @@
   </head>
   <body>
     <div class="wrapper">
-      <% 52.times do |week| %>
+      <% granularity.times do |n| %>
         <div>
           <% LIFE_YEARS.times do |year| %>
-            <span class="<%= lived?(year, week) %>"></span>
+            <span class="<%= lived?(year, n) %>"></span>
           <% end %>
         </div>
       <% end %>


### PR DESCRIPTION
Add "by month" granularity for more command line friendliness:
![screenshot from 2016-04-20 16-30-53](https://cloud.githubusercontent.com/assets/1682086/14676539/8ce7dc86-0716-11e6-95f2-782b0cf3dc8d.png)

@spajus 
